### PR TITLE
feat: JPA 환경설정별 hibernate 옵션 설정 추가 및 Ticket 도메인 수정

### DIFF
--- a/src/main/java/com/kb/wallet/global/config/JpaConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/JpaConfig.java
@@ -1,5 +1,6 @@
 package com.kb.wallet.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,7 @@ import javax.sql.DataSource;
 import java.util.Properties;
 
 @Configuration
+@Slf4j
 public class JpaConfig {
 
   @Configuration
@@ -32,10 +34,11 @@ public class JpaConfig {
     public Properties jpaProperties() {
       Properties properties = new Properties();
       properties.put("hibernate.hbm2ddl.auto", "update");
-      properties.put("hibernate.dialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
+      properties.put("hibernate.dialect", "org.hibernate.dialect.MySQL8Dialect");
       properties.put("hibernate.show_sql", "true");
       properties.put("hibernate.physical_naming_strategy",
           "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+      log.info("db1: {}", properties.get("hibernate.hbm2ddl.auto"));
       return properties;
     }
   }
@@ -62,6 +65,7 @@ public class JpaConfig {
       properties.put("hibernate.show_sql", "false");
       properties.put("hibernate.physical_naming_strategy",
           "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+      log.info("db2: {}", properties.get("hibernate.hbm2ddl.auto"));
       return properties;
     }
   }
@@ -82,11 +86,13 @@ public class JpaConfig {
     @Bean
     public Properties jpaProperties() {
       Properties properties = new Properties();
-      properties.put("hibernate.hbm2ddl.auto", "update");
-      properties.put("hibernate.dialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
+      properties.put("hibernate.hbm2ddl.auto", "create");
+      properties.put("hibernate.dialect", "org.hibernate.dialect.MySQL8Dialect");
       properties.put("hibernate.show_sql", "true");
       properties.put("hibernate.physical_naming_strategy",
           "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+      log.info("db3 datasourceUrl: {}", datasourceUrl);
+      log.info("db3: {}", properties.get("hibernate.hbm2ddl.auto"));
       return properties;
     }
   }

--- a/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
+++ b/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
@@ -57,7 +57,7 @@ public class Ticket {
   private TicketStatus ticketStatus;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "seat_id", unique = true)
+  @JoinColumn(name = "seat_id", unique = false)
   private Seat seat;
 
   @Column(updatable = false)


### PR DESCRIPTION


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  - [ ] 기능 추가
  - [x] 기능 수정
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 테스트 추가/수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/global-setting/chs -> dev

### 변경 사항
- 각 환경(dev, prod, test)에 맞는 hibernate.hbm2ddl.auto 옵션을 설정함 dev: update, test: create, prod: none 설정.
- Ticket 도메인의 seatId 필드의 unique 제약 조건을 false로 변경

### 검증 여부
- [x] build 확인
