### PR TITLE
Feat: `Seat` 도메인에 비관락 적용

### DIFF
--- a/src/main/java/com/kb/wallet/seat/service/SeatService.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatService.java
@@ -5,4 +5,5 @@ import com.kb.wallet.seat.domain.Seat;
 public interface SeatService {
 
   Seat getSeatById(Long seatId);
+  Seat getSeatByIdWithLock(Long seatId);
 }

--- a/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
@@ -18,4 +18,10 @@ public class SeatServiceImpl implements SeatService {
     return seatRepository.findByIdWithLock(seatId)
         .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND_ERROR));
   }
+
+  @Override
+  public Seat getSeatByIdWithLock(Long seatId) {
+    return seatRepository.findByIdWithLock(seatId)
+        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND_ERROR));
+  }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  - [ ] 기능 추가
  - [x] 기능 수정
  - [ ] 기능 삭제
  - [x] 버그 수정
  - [ ] 테스트 추가/수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/ticketing/concurrency/pessimistic/chs -> main

### 변경 사항
- 동시성 문제 해결 전과 비교할 수 있게 SeatService에 적용 전, 후에 대한 메소드를 분리함.
- entityManager.flush를 사용해서 Seat 상태를 DB에 반영하도록 강제함
- Seat 상태 변경 전에 트랜잭션 커밋 문제로 saveTicket() 메서드를 분리하여 JPA의 save을 맨 마지막으로 배치함.

### 검증 여부
- [ ] postman으로 api 테스트 완료했습니다.
- [x] 로컬 test 환경에서 JUnit 테스트 코드 실행 및 통과.
  - ![pessimistic](https://github.com/user-attachments/assets/cee57022-73a4-44ad-85a2-4dcb7cfb3786)

